### PR TITLE
Remove the max width of the content body and add extra white space above the footer

### DIFF
--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -22,8 +22,8 @@ const Layout: FC<LayoutProps> = ({ children }) => {
       <main aria-label="CCDI CBIO Main Section">
         <Container
           maxWidth={false}
-          sx={{ minHeight: '600px'}}
-          style={{paddingLeft: 0, paddingRight: 0, maxWidth: 1600, minHeight: '300px'}}
+          sx={{minHeight: 600}}
+          style={{paddingLeft: 0, paddingRight: 0, paddingBottom: 70, minHeight: 300}}
         >
           <Box display="flex">
             {children || <Outlet />}


### PR DESCRIPTION
This PR removes the max width of the content body and adds extra white space above the footer.