### PR TITLE
Add About link to the footer

### DIFF
--- a/src/config/globalFooterData.tsx
+++ b/src/config/globalFooterData.tsx
@@ -19,6 +19,10 @@ export default {
       title: 'About',
       items: [
         {
+          text: 'About CCDI cBioPortal',
+          link: '/about-ccdi-cbioportal',
+        },
+        {
           text: 'About CCDI Hub',
           link: 'https://ccdi.cancer.gov/about',
         },


### PR DESCRIPTION
This PR adds CCDI cBioPortal about page link to the footer.