### PR TITLE
Update footer contact link

### DIFF
--- a/src/config/globalFooterData.tsx
+++ b/src/config/globalFooterData.tsx
@@ -35,17 +35,13 @@ export default {
           link: 'https://docs.cbioportal.org/about-us/',
         },
         {
-          text: 'Contact CCDI Hub',
+          text: 'Contact Us',
           link: 'mailto:NCIChildhoodCancerDataInitiative@mail.nih.gov',
         },
       ],
     }, {
       title: 'Resources',
       items: [
-        {
-          text: 'Contact Us',
-          link: 'https://www.cancer.gov/contact',
-        },
         {
           text: 'Publications',
           link: 'https://www.cancer.gov/publications',


### PR DESCRIPTION
This PR updates footer contact links.
- Move "Contact Us" link from Resources to About section
- Remove duplicate "Contact Us" link from Resources section  
- Rename "Contact CCDI Hub" to "Contact Us" for consistency
- Consolidate contact information in About section