### PR TITLE
refactor: simplify bottom footer contact links

### DIFF
--- a/src/config/globalFooterData.tsx
+++ b/src/config/globalFooterData.tsx
@@ -39,7 +39,8 @@ export default {
           link: 'mailto:NCIChildhoodCancerDataInitiative@mail.nih.gov',
         },
       ],
-    }, {
+    },
+    {
       title: 'Resources',
       items: [
         {

--- a/src/config/globalFooterData.tsx
+++ b/src/config/globalFooterData.tsx
@@ -115,20 +115,8 @@ export default {
   ],
   contact_links: [
     {
-      text: 'Live chat',
-      link: 'https://livehelp.cancer.gov/',
-    },
-    {
-      text: '1-800-4-CANCER',
-      link: 'tel:+18004226237',
-    },
-    {
       text: 'NCIChildhoodCancerDataInitiative@mail.nih.gov',
       link: 'mailto:NCIChildhoodCancerDataInitiative@mail.nih.gov',
-    },
-    {
-      text: 'Site Feedback',
-      link: 'https://nci.az1.qualtrics.com/jfe/form/SV_aeLLobt6ZeGVn5I',
     },
   ],
   global_footer_links: [


### PR DESCRIPTION
This PR removes redundant contact options from footer contact_links section:
- Remove Live chat link
- Remove 1-800-4-CANCER phone number
- Remove Site Feedback link
- Keep only CCDI email contact for streamlined user experience