### PR TITLE
fix(NavbarDesktop): cap dropdown item width at 250px

### DIFF
--- a/src/components/Header/components/NavbarDesktop.tsx
+++ b/src/components/Header/components/NavbarDesktop.tsx
@@ -203,6 +203,7 @@ const DropdownContainer = styled.div`
   }
 
   .dropdownItem {
+    max-width: 250px;
     padding: 0 0 2.5rem 0;
     text-align: left;
     font-family: 'Poppins';


### PR DESCRIPTION
This PR caps dropdown item width at 250px.
- Add max-width: 250px to .dropdownItem to align with grid (minmax 250px) and prevent overflow/wrapping in desktop dropdowns.