### PR TITLE
Add env-configured URL

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -4,8 +4,7 @@ import StaticContentIframePage from './iframe/StaticContentIframePage';
 const About: FC = () => {
   return (
     <StaticContentIframePage
-      localUrl={process.env.REACT_APP_CCDI_CBIO_ABOUT_URL}
-      liveUrl="https://cbiit.github.io/ccdi-cbio-content-ui/about"
+      url={process.env.REACT_APP_CCDI_CBIO_ABOUT_URL}
       id="about-ccdi-cbioportal"
       title="About CCDI cBioPortal"
     />

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -4,7 +4,7 @@ import StaticContentIframePage from './iframe/StaticContentIframePage';
 const About: FC = () => {
   return (
     <StaticContentIframePage
-      url={process.env.REACT_APP_CCDI_CBIO_ABOUT_URL}
+      url={process.env.REACT_APP_CCDI_CBIO_ABOUT_URL || ''}
       id="about-ccdi-cbioportal"
       title="About CCDI cBioPortal"
     />

--- a/src/pages/ReleaseNotes.tsx
+++ b/src/pages/ReleaseNotes.tsx
@@ -4,7 +4,7 @@ import StaticContentIframePage from './iframe/StaticContentIframePage';
 const ReleaseNotes: FC = () => {
   return (
     <StaticContentIframePage
-      url={process.env.REACT_APP_CCDI_CBIO_CONTENT_UI_URL}
+      url={process.env.REACT_APP_CCDI_CBIO_CONTENT_UI_URL || ''}
       id="dataset-and-release-notes"
       title="Dataset and Release Notes"
     />

--- a/src/pages/ReleaseNotes.tsx
+++ b/src/pages/ReleaseNotes.tsx
@@ -4,8 +4,7 @@ import StaticContentIframePage from './iframe/StaticContentIframePage';
 const ReleaseNotes: FC = () => {
   return (
     <StaticContentIframePage
-      localUrl={process.env.REACT_APP_CCDI_CBIO_CONTENT_UI_URL}
-      liveUrl="https://cbiit.github.io/ccdi-cbio-content-ui"
+      url={process.env.REACT_APP_CCDI_CBIO_CONTENT_UI_URL}
       id="dataset-and-release-notes"
       title="Dataset and Release Notes"
     />

--- a/src/pages/iframe/StaticContentIframePage.tsx
+++ b/src/pages/iframe/StaticContentIframePage.tsx
@@ -5,25 +5,15 @@ import IframeOverlay from './IframeOverlay';
 import { DropdownContext } from '../../store/navbar-dropdown-context';
 
 const StaticContentIframePage: FC<{
-  localUrl: string,
-  liveUrl: string,
+  url: string,
   id: string,
   title: string
-}> = ({ localUrl, liveUrl, id, title }) => {
+}> = ({ url, id, title }) => {
   const { clickedTitle, setClickedTitle } = useContext(DropdownContext);
   const [srcUrl, setSrcUrl] = useState<string>('');
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const tierName = window.location.hostname.split('.')[0].split('-')[1];
-      const isLocalEnv = process.env.NODE_ENV === 'development';
-      const isDevEnv = (tierName === 'dev') || (tierName === 'qa');
-      if (isLocalEnv) {
-        setSrcUrl(localUrl);
-      } else {
-        setSrcUrl(isDevEnv ? `${liveUrl}?dev` : liveUrl);
-      }
-    }
+    setSrcUrl(url);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
This pull request refactors how static content URLs are handled in the `StaticContentIframePage` component and its usage across the app. The main change is simplifying the component's interface to use a single `url` prop instead of separate `localUrl` and `liveUrl` props, and streamlining the logic for setting the iframe source URL.

Component API simplification:

* Changed the `StaticContentIframePage` component to accept a single `url` prop instead of `localUrl` and `liveUrl`, and updated its usage in both `About.tsx` and `ReleaseNotes.tsx` to match the new interface. [[1]](diffhunk://#diff-c38edb3d096feacef4f7f0deec7152152bfe0742a43948deb9df9989901ce76eL8-R16) [[2]](diffhunk://#diff-3a6aff1def85e55c8efb21b12b991c33970efde35385d875d9b3c7d476b6b291L7-R7) [[3]](diffhunk://#diff-48de23e149b38f2358ccaef6abd4d664dab455c28f51632508e81bf82f7c2fc0L7-R7)

Logic simplification:

* Removed environment and hostname-based logic for determining the iframe source URL in `StaticContentIframePage`, now simply setting the iframe source to the provided `url` prop.