### PR TITLE
Update page title and add iframe local-network-access permission

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>CCDI CBIO</title>
+    <title>Childhood Cancer Data Initiative (CCDI) cBioPortal</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -17,7 +17,7 @@ const Layout: FC<LayoutProps> = ({ children }) => {
   return (
     <DropdownContext.Provider value={{ clickedTitle, setClickedTitle }}>
       <Helmet>
-        <title>CCDI cBioPortal</title>
+        <title>Childhood Cancer Data Initiative (CCDI) cBioPortal</title>
         <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Poppins:wght@400;700&family=Lato:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&family=Nunito+Sans:wght@400;500;600;700;900&family=Nunito:wght@400;500;600;700&family=Public+Sans:wght@300;400;500;600;700&family=Rubik:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
       </Helmet>
       <Header />

--- a/src/pages/iframe/IframeBody.tsx
+++ b/src/pages/iframe/IframeBody.tsx
@@ -69,6 +69,7 @@ export default function IframeBody({
         className={className}
         $height={height}
         $width={width}
+        allow="local-network-access"
         {...props}
       />
       {children}


### PR DESCRIPTION
This pull request updates the application’s branding and improves iframe functionality. The most important changes are grouped below:

Branding updates:

* Changed the site title in both `public/index.html` and the React `Layout` component to "Childhood Cancer Data Initiative (CCDI) cBioPortal" for consistency and clearer branding. [[1]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL35-R35) [[2]](diffhunk://#diff-bf519b3befa6958992e2ebf45606dcb00d277b114afb0d3612b51a2b46068157L20-R20)

Iframe functionality:

* Added the `allow="local-network-access"` attribute to the iframe in `src/pages/iframe/IframeBody.tsx` to enable local network access from embedded content.