### PR TITLE
Add all tab routes

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -55,7 +55,15 @@ const routes: RouteObject[] = [
         element: <Study />
       },
       {
+        path: '/study/heatmaps',
+        element: <Study />
+      },
+      {
         path: '/study/cnSegments',
+        element: <Study />
+      },
+      {
+        path: '/study/filesAndLinks',
         element: <Study />
       },
       {
@@ -68,6 +76,10 @@ const routes: RouteObject[] = [
       },
       {
         path: '/results/oncoprint',
+        element: <Results />
+      },
+      {
+        path: '/results/survival',
         element: <Results />
       },
       {
@@ -91,6 +103,10 @@ const routes: RouteObject[] = [
         element: <Results />
       },
       {
+        path: '/results/coexpression',
+        element: <Results />
+      },
+      {
         path: '/results/comparison',
         element: <Results />
       },
@@ -99,7 +115,15 @@ const routes: RouteObject[] = [
         element: <Results />
       },
       {
+        path: '/results/network',
+        element: <Results />
+      },
+      {
         path: '/results/pathways',
+        element: <Results />
+      },
+      {
+        path: '/results/expression',
         element: <Results />
       },
       {
@@ -115,11 +139,39 @@ const routes: RouteObject[] = [
         element: <Patient />
       },
       {
-        path: '/patient/pathways',
+        path: '/patient/genomicEvolution',
         element: <Patient />
       },
       {
         path: '/patient/clinicalData',
+        element: <Patient />
+      },
+      {
+        path: '/patient/filesAndLinks',
+        element: <Patient />
+      },
+      {
+        path: '/patient/pathologyReport',
+        element: <Patient />
+      },
+      {
+        path: '/patient/tissueImage',
+        element: <Patient />
+      },
+      {
+        path: '/patient/MSKTissueImage',
+        element: <Patient />
+      },
+      {
+        path: '/patient/trialMatchTab',
+        element: <Patient />
+      },
+      {
+        path: '/patient/mutationalSignatures',
+        element: <Patient />
+      },
+      {
+        path: '/patient/pathways',
         element: <Patient />
       },
       {
@@ -135,6 +187,14 @@ const routes: RouteObject[] = [
         element: <Comparison />
       },
       {
+        path: '/comparison/mrna',
+        element: <Comparison />
+      },
+      {
+        path: '/comparison/protein',
+        element: <Comparison />
+      },
+      {
         path: '/comparison/survival',
         element: <Comparison />
       },
@@ -143,11 +203,31 @@ const routes: RouteObject[] = [
         element: <Comparison />
       },
       {
+        path: '/comparison/dna_methylation',
+        element: <Comparison />
+      },
+      {
         path: '/comparison/alterations',
         element: <Comparison />
       },
       {
+        path: '/comparison/generic_assay',
+        element: <Comparison />
+      },
+      {
+        path: '/comparison/generic_assay_binary',
+        element: <Comparison />
+      },
+      {
+        path: '/comparison/generic_assay_categorical',
+        element: <Comparison />
+      },
+      {
         path: '/comparison/mutations',
+        element: <Comparison />
+      },
+      {
+        path: '/comparison/pathways',
         element: <Comparison />
       },
       {


### PR DESCRIPTION
This pull request expands the application's routing configuration in `src/router.tsx` by adding several new routes across multiple sections, enhancing support for new data views and features. These changes make the app more modular and allow for easier navigation to specialized data and analysis pages.

**New Study and Results Routes:**

* Added routes for `heatmaps` and `filesAndLinks` under `/study`, and several new result views under `/results` such as `survival`, `coexpression`, `network`, and `expression`. These additions support new types of study and results data visualization and access. [[1]](diffhunk://#diff-2194a569c1e2cb2d5e6be82f85a9b8aa671cb1178cec3dabf1910af929285cb2R57-R68) [[2]](diffhunk://#diff-2194a569c1e2cb2d5e6be82f85a9b8aa671cb1178cec3dabf1910af929285cb2R81-R84) [[3]](diffhunk://#diff-2194a569c1e2cb2d5e6be82f85a9b8aa671cb1178cec3dabf1910af929285cb2R105-R108) [[4]](diffhunk://#diff-2194a569c1e2cb2d5e6be82f85a9b8aa671cb1178cec3dabf1910af929285cb2R117-R128)

**Expanded Patient Data Views:**

* Introduced new patient-related routes including `filesAndLinks`, `pathologyReport`, various tissue image views, `trialMatchTab`, and `mutationalSignatures`. Also, the previous `/patient/pathways` route was replaced with `/patient/genomicEvolution` and `/patient/pathways` was re-added, allowing for more granular patient data exploration.

**Additional Comparison Features:**

* Added multiple comparison routes for different assay types (`mrna`, `protein`, `dna_methylation`, `generic_assay`, `generic_assay_binary`, `generic_assay_categorical`, and `pathways`). This greatly increases the flexibility and depth of comparative analysis within the app. [[1]](diffhunk://#diff-2194a569c1e2cb2d5e6be82f85a9b8aa671cb1178cec3dabf1910af929285cb2R189-R196) [[2]](diffhunk://#diff-2194a569c1e2cb2d5e6be82f85a9b8aa671cb1178cec3dabf1910af929285cb2R205-R232)