### PR TITLE
Update to include all tab routes

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -47,27 +47,7 @@ const routes: RouteObject[] = [
         element: <Study />
       },
       {
-        path: '/study/summary',
-        element: <Study />
-      },
-      {
-        path: '/study/clinicalData',
-        element: <Study />
-      },
-      {
-        path: '/study/heatmaps',
-        element: <Study />
-      },
-      {
-        path: '/study/cnSegments',
-        element: <Study />
-      },
-      {
-        path: '/study/filesAndLinks',
-        element: <Study />
-      },
-      {
-        path: '/study/plots',
+        path: '/study/:tabId',
         element: <Study />
       },
       {
@@ -75,59 +55,7 @@ const routes: RouteObject[] = [
         element: <Results />
       },
       {
-        path: '/results/oncoprint',
-        element: <Results />
-      },
-      {
-        path: '/results/survival',
-        element: <Results />
-      },
-      {
-        path: '/results/cancerTypesSummary',
-        element: <Results />
-      },
-      {
-        path: '/results/mutualExclusivity',
-        element: <Results />
-      },
-      {
-        path: '/results/plots',
-        element: <Results />
-      },
-      {
-        path: '/results/mutations',
-        element: <Results />
-      },
-      {
-        path: '/results/structuralVariants',
-        element: <Results />
-      },
-      {
-        path: '/results/coexpression',
-        element: <Results />
-      },
-      {
-        path: '/results/comparison',
-        element: <Results />
-      },
-      {
-        path: '/results/cnSegments',
-        element: <Results />
-      },
-      {
-        path: '/results/network',
-        element: <Results />
-      },
-      {
-        path: '/results/pathways',
-        element: <Results />
-      },
-      {
-        path: '/results/expression',
-        element: <Results />
-      },
-      {
-        path: '/results/download',
+        path: '/results/:tabId',
         element: <Results />
       },
       {
@@ -135,43 +63,7 @@ const routes: RouteObject[] = [
         element: <Patient />
       },
       {
-        path: '/patient/summary',
-        element: <Patient />
-      },
-      {
-        path: '/patient/genomicEvolution',
-        element: <Patient />
-      },
-      {
-        path: '/patient/clinicalData',
-        element: <Patient />
-      },
-      {
-        path: '/patient/filesAndLinks',
-        element: <Patient />
-      },
-      {
-        path: '/patient/pathologyReport',
-        element: <Patient />
-      },
-      {
-        path: '/patient/tissueImage',
-        element: <Patient />
-      },
-      {
-        path: '/patient/MSKTissueImage',
-        element: <Patient />
-      },
-      {
-        path: '/patient/trialMatchTab',
-        element: <Patient />
-      },
-      {
-        path: '/patient/mutationalSignatures',
-        element: <Patient />
-      },
-      {
-        path: '/patient/pathways',
+        path: '/patient/:tabId',
         element: <Patient />
       },
       {
@@ -183,51 +75,7 @@ const routes: RouteObject[] = [
         element: <Comparison />
       },
       {
-        path: '/comparison/overlap',
-        element: <Comparison />
-      },
-      {
-        path: '/comparison/mrna',
-        element: <Comparison />
-      },
-      {
-        path: '/comparison/protein',
-        element: <Comparison />
-      },
-      {
-        path: '/comparison/survival',
-        element: <Comparison />
-      },
-      {
-        path: '/comparison/clinical',
-        element: <Comparison />
-      },
-      {
-        path: '/comparison/dna_methylation',
-        element: <Comparison />
-      },
-      {
-        path: '/comparison/alterations',
-        element: <Comparison />
-      },
-      {
-        path: '/comparison/generic_assay',
-        element: <Comparison />
-      },
-      {
-        path: '/comparison/generic_assay_binary',
-        element: <Comparison />
-      },
-      {
-        path: '/comparison/generic_assay_categorical',
-        element: <Comparison />
-      },
-      {
-        path: '/comparison/mutations',
-        element: <Comparison />
-      },
-      {
-        path: '/comparison/pathways',
+        path: '/comparison/:tabId',
         element: <Comparison />
       },
       {


### PR DESCRIPTION
This pull request refactors the route definitions in `src/router.tsx` to simplify the routing structure for the main application sections. Instead of defining a separate route for each tab or subpage, the code now uses a dynamic `:tabId` parameter for each section, which makes the routing more maintainable and scalable.

**Routing simplification:**

* Replaced multiple explicit tab routes for the `Study`, `Results`, `Patient`, and `Comparison` sections with a single dynamic route using the `:tabId` parameter (e.g., `/study/:tabId`, `/results/:tabId`, `/patient/:tabId`, `/comparison/:tabId`). This reduces redundancy and centralizes route handling for each section. [[1]](diffhunk://#diff-2194a569c1e2cb2d5e6be82f85a9b8aa671cb1178cec3dabf1910af929285cb2L50-R66) [[2]](diffhunk://#diff-2194a569c1e2cb2d5e6be82f85a9b8aa671cb1178cec3dabf1910af929285cb2L186-R78)