### PR TITLE
Remove allow attribute from iframe

### DIFF
--- a/src/pages/iframe/IframeBody.tsx
+++ b/src/pages/iframe/IframeBody.tsx
@@ -69,7 +69,6 @@ export default function IframeBody({
         className={className}
         $height={height}
         $width={width}
-        allow="local-network-access"
         {...props}
       />
       {children}


### PR DESCRIPTION
This pull request makes a minor change to the `IframeBody` component by removing the `allow="local-network-access"` attribute from the rendered iframe.