### PR TITLE
Add local-network-access to dev, qa and stage

### DIFF
--- a/src/pages/iframe/IframeBody.tsx
+++ b/src/pages/iframe/IframeBody.tsx
@@ -60,7 +60,16 @@ export default function IframeBody({
   children,
   ...props
 }: IframeBodyProps) {
-  const isNotProd = ['-dev', '-qa', '-stage'].some(env => srcUrl.includes(env));
+  // Add local-network-access allow if the hostname includes -dev, -qa, or -stage
+  let isNonProd = false;
+  try {
+    const hostname = new URL(srcUrl, window.location.origin).hostname;
+    isNonProd = ['-dev', '-qa', '-stage'].some(env => hostname.includes(env));
+  } catch (e) {
+    // If srcUrl is not a valid URL, set isNonProd to false
+    isNonProd = false;
+  }
+
   return (
     <>
       <StyledIframe
@@ -70,7 +79,7 @@ export default function IframeBody({
         className={className}
         $height={height}
         $width={width}
-        allow={isNotProd ? "local-network-access" : undefined}
+        allow={isNonProd ? "local-network-access" : undefined}
         {...props}
       />
       {children}

--- a/src/pages/iframe/IframeBody.tsx
+++ b/src/pages/iframe/IframeBody.tsx
@@ -60,6 +60,7 @@ export default function IframeBody({
   children,
   ...props
 }: IframeBodyProps) {
+  const isNotProd = ['-dev', '-qa', '-stage'].some(env => srcUrl.includes(env));
   return (
     <>
       <StyledIframe
@@ -69,7 +70,7 @@ export default function IframeBody({
         className={className}
         $height={height}
         $width={width}
-        allow={srcUrl.includes('-dev') || srcUrl.includes('-qa') || srcUrl.includes('-stage') ? "local-network-access" : undefined}
+        allow={isNotProd ? "local-network-access" : undefined}
         {...props}
       />
       {children}

--- a/src/pages/iframe/IframeBody.tsx
+++ b/src/pages/iframe/IframeBody.tsx
@@ -69,7 +69,7 @@ export default function IframeBody({
         className={className}
         $height={height}
         $width={width}
-        allow="local-network-access"
+        allow={srcUrl.includes('-dev') || srcUrl.includes('-qa') || srcUrl.includes('-stage') ? "local-network-access" : undefined}
         {...props}
       />
       {children}


### PR DESCRIPTION
This pull request introduces a conditional change to the `IframeBody` component to improve security and flexibility when embedding iframes. The `allow` attribute for local network access is now only set for specific environments.

Iframe security improvement:

* [`src/pages/iframe/IframeBody.tsx`](diffhunk://#diff-7c14988f0b6f167891a73010df402c15f8376801d74c83f6dab85d39a712b977L72-R72): The `allow` attribute is now set to `"local-network-access"` only if the `srcUrl` contains `-dev`, `-qa`, or `-stage`, otherwise it is left undefined. This restricts local network access to development, QA, and staging environments, enhancing production security.