### PR TITLE
Update padding bottom

### DIFF
--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -29,15 +29,15 @@ const Layout: FC<LayoutProps> = ({ children }) => {
             '@media (min-width: 1023px)': {
               paddingLeft: 0,
               paddingRight: 0,
-              paddingBottom: '70px',
+              paddingBottom: '46px',
             },
             '@media (min-width: 767px) and (max-width: 1023px)': {
-              paddingBottom: '60px',
+              paddingBottom: '36px',
               paddingLeft: 0,
               paddingRight: 0,
             },
             '@media (max-width: 767px)': {
-              paddingBottom: '60px',
+              paddingBottom: '36px',
               paddingLeft: 0,
               paddingRight: 0,
             },

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -32,12 +32,12 @@ const Layout: FC<LayoutProps> = ({ children }) => {
               paddingBottom: '46px',
             },
             '@media (min-width: 767px) and (max-width: 1023px)': {
-              paddingBottom: '36px',
+              paddingBottom: '40px',
               paddingLeft: 0,
               paddingRight: 0,
             },
             '@media (max-width: 767px)': {
-              paddingBottom: '36px',
+              paddingBottom: '40px',
               paddingLeft: 0,
               paddingRight: 0,
             },


### PR DESCRIPTION
This pull request makes a small adjustment to the layout padding across different screen sizes. The bottom padding has been reduced for all breakpoints in the `Layout` component.

- Decreased the `paddingBottom` values for desktop, tablet, and mobile breakpoints in the `Layout` component (`src/layouts/index.tsx`).