### PR TITLE
Adjust trivial stylings

### DIFF
--- a/src/components/OverlayWindow/OverlayThemeConfig.tsx
+++ b/src/components/OverlayWindow/OverlayThemeConfig.tsx
@@ -33,6 +33,7 @@ const overlayComponents = {
   MuiDialogContent: {
     styleOverrides: {
       root: {
+        lineHeight: '1.15',
         color: '#000045',
         '& p': {
           fontSize: '14px',
@@ -65,6 +66,7 @@ const overlayComponents = {
   MuiList: {
     styleOverrides: {
       root: {
+        marginTop: '1.5px !important',
         fontSize: '14px',
       },
       padding: {


### PR DESCRIPTION
This pull request makes minor adjustments to the overlay component theme configuration to improve visual consistency.

* Visual style improvements:
  * Added a `lineHeight` of `1.15` to the `MuiDialogContent` root style for better text spacing.
  * Added a `marginTop` of `1.5px !important` to the `MuiList` root style to enhance layout alignment.