### PR TITLE
Switch to using local storage

### DIFF
--- a/src/components/OverlayWindow/OverlayWindow.tsx
+++ b/src/components/OverlayWindow/OverlayWindow.tsx
@@ -16,7 +16,7 @@ import FiberManualRecord from '@mui/icons-material/FiberManualRecord';
 import text from './OverlayText.json';
 import DialogThemeProvider from './OverlayThemeConfig';
 
-const OVERLAY_LOAD_SESSION_STORAGE = 'overlayLoad';
+const OVERLAY_LOAD_LOCAL_STORAGE = 'overlayLoad';
 
 const OverlayWindow = () => {
   const [open, setOpen] = useState(false);
@@ -24,20 +24,20 @@ const OverlayWindow = () => {
   const handleClose = () => {
     setOpen(false);
     try {
-      sessionStorage.setItem(OVERLAY_LOAD_SESSION_STORAGE, 'true');
+      localStorage.setItem(OVERLAY_LOAD_LOCAL_STORAGE, 'true');
     } catch (error) {
-      console.error('Error setting session storage:', error);
+      console.error('Error setting local storage:', error);
     }
   };
 
   useEffect(() => {
     try {
-      const isOverlayLoaded = sessionStorage.getItem(OVERLAY_LOAD_SESSION_STORAGE);
+      const isOverlayLoaded = localStorage.getItem(OVERLAY_LOAD_LOCAL_STORAGE);
       if (!isOverlayLoaded) {
         setOpen(true);
       }
     } catch (error) {
-      console.error('Error getting session storage:', error);
+      console.error('Error getting local storage:', error);
       setOpen(true);
     }
   }, []);


### PR DESCRIPTION
This pull request updates the storage mechanism used to track whether the overlay window has been shown to the user. The logic now uses `localStorage` instead of `sessionStorage`, ensuring the overlay is only shown once across browser sessions rather than once per session.

**Persistence mechanism update:**

* Changed all references in `OverlayWindow.tsx` from `sessionStorage` to `localStorage` for storing and retrieving the overlay load state, so the overlay is only shown once per user rather than per session.