### PR TITLE
Datasets tab gets refreshed when clicked

### DIFF
--- a/src/components/Header/HeaderMobile.tsx
+++ b/src/components/Header/HeaderMobile.tsx
@@ -247,6 +247,8 @@ const Header = () => {
                           id={navMobileItem.id}
                           to={navMobileItem.link}
                           reloadDocument={navMobileItem.reloadDocument}
+                          target={navMobileItem.external ? "_blank" : null}
+                          rel={navMobileItem.external ? "noopener noreferrer" : null}
                           onClick={() => setNavMobileDisplay('none')}
                         >
                           <div className="navMobileItem">{navMobileItem.name}</div>
@@ -265,7 +267,12 @@ const Header = () => {
                       }
                       {
                         navMobileItem.className === 'navMobileSubItem' &&
-                        <Link id={navMobileItem.id} to={navMobileItem.link}>
+                        <Link
+                          id={navMobileItem.id}
+                          to={navMobileItem.link}
+                          target={navMobileItem.external ? "_blank" : null}
+                          rel={navMobileItem.external ? "noopener noreferrer" : null}
+                        >
                           <div
                             role="button"
                             tabIndex={0}

--- a/src/components/Header/HeaderMobile.tsx
+++ b/src/components/Header/HeaderMobile.tsx
@@ -241,9 +241,45 @@ const Header = () => {
                   const mobilekey = `mobile_${idx}`;
                   return (
                     <React.Fragment key={mobilekey}>
-                      {navMobileItem.className === 'navMobileItem' && <NavLink id={navMobileItem.id} to={navMobileItem.link} onClick={() => setNavMobileDisplay('none')}><div className="navMobileItem">{navMobileItem.name}</div></NavLink>}
-                      {navMobileItem.className === 'navMobileItem clickable' && <div id={navMobileItem.id} role="button" tabIndex={0} className="navMobileItem clickable" onKeyDown={(e) => { if (e.key === "Enter") { clickNavItem(e); } }} onClick={clickNavItem}>{navMobileItem.name}</div>}
-                      {navMobileItem.className === 'navMobileSubItem' && <Link id={navMobileItem.id} to={navMobileItem.link}><div role="button" tabIndex={0} className="navMobileItem SubItem" onKeyDown={(e) => { if (e.key === "Enter") { setNavMobileDisplay('none'); } }} onClick={() => setNavMobileDisplay('none')}>{navMobileItem.name}</div></Link>}
+                      {
+                        navMobileItem.className === 'navMobileItem' &&
+                        <NavLink
+                          id={navMobileItem.id}
+                          to={navMobileItem.link}
+                          reloadDocument={
+                            navMobileItem.id === 'navbar-link-home' ||
+                            navMobileItem.id === 'navbar-link-datasets'
+                          }
+                          onClick={() => setNavMobileDisplay('none')}
+                        >
+                          <div className="navMobileItem">{navMobileItem.name}</div>
+                        </NavLink>
+                      }
+                      {
+                        navMobileItem.className === 'navMobileItem clickable' &&
+                        <div
+                          id={navMobileItem.id}
+                          role="button"
+                          tabIndex={0}
+                          className="navMobileItem clickable"
+                          onKeyDown={(e) => { if (e.key === "Enter") { clickNavItem(e); } }}
+                          onClick={clickNavItem}>{navMobileItem.name}
+                        </div>
+                      }
+                      {
+                        navMobileItem.className === 'navMobileSubItem' &&
+                        <Link id={navMobileItem.id} to={navMobileItem.link}>
+                          <div
+                            role="button"
+                            tabIndex={0}
+                            className="navMobileItem SubItem"
+                            onKeyDown={(e) => { if (e.key === "Enter") { setNavMobileDisplay('none'); } }}
+                            onClick={() => setNavMobileDisplay('none')}
+                          >
+                            {navMobileItem.name}
+                          </div>
+                        </Link>
+                      }
                       {navMobileItem.className === 'navMobileSubTitle' && <div className="navMobileItem">{navMobileItem.name}</div>}
                     </React.Fragment>
                   );

--- a/src/components/Header/HeaderMobile.tsx
+++ b/src/components/Header/HeaderMobile.tsx
@@ -246,10 +246,7 @@ const Header = () => {
                         <NavLink
                           id={navMobileItem.id}
                           to={navMobileItem.link}
-                          reloadDocument={
-                            navMobileItem.id === 'navbar-link-home' ||
-                            navMobileItem.id === 'navbar-link-datasets'
-                          }
+                          reloadDocument={navMobileItem.reloadDocument}
                           onClick={() => setNavMobileDisplay('none')}
                         >
                           <div className="navMobileItem">{navMobileItem.name}</div>

--- a/src/components/Header/HeaderTablet.tsx
+++ b/src/components/Header/HeaderTablet.tsx
@@ -235,6 +235,8 @@ const Header = () => {
                           id={navMobileItem.id}
                           to={navMobileItem.link}
                           reloadDocument={navMobileItem.reloadDocument}
+                          target={navMobileItem.external ? "_blank" : null}
+                          rel={navMobileItem.external ? "noopener noreferrer" : null}
                           onClick={() => setNavMobileDisplay('none')}
                         >
                           <div className="navMobileItem">{navMobileItem.name}</div>
@@ -253,7 +255,12 @@ const Header = () => {
                       }
                       {
                         navMobileItem.className === 'navMobileSubItem' &&
-                        <Link id={navMobileItem.id} to={navMobileItem.link}>
+                        <Link
+                          id={navMobileItem.id}
+                          to={navMobileItem.link}
+                          target={navMobileItem.external ? "_blank" : null}
+                          rel={navMobileItem.external ? "noopener noreferrer" : null}
+                        >
                           <div
                             role="button"
                             tabIndex={0}

--- a/src/components/Header/HeaderTablet.tsx
+++ b/src/components/Header/HeaderTablet.tsx
@@ -234,10 +234,7 @@ const Header = () => {
                         <NavLink
                           id={navMobileItem.id}
                           to={navMobileItem.link}
-                          reloadDocument={
-                            navMobileItem.id === 'navbar-link-home' ||
-                            navMobileItem.id === 'navbar-link-datasets'
-                          }
+                          reloadDocument={navMobileItem.reloadDocument}
                           onClick={() => setNavMobileDisplay('none')}
                         >
                           <div className="navMobileItem">{navMobileItem.name}</div>

--- a/src/components/Header/HeaderTablet.tsx
+++ b/src/components/Header/HeaderTablet.tsx
@@ -229,9 +229,43 @@ const Header = () => {
                   const mobilekey = `mobile_${idx}`;
                   return (
                     <React.Fragment key={mobilekey}>
-                      {navMobileItem.className === 'navMobileItem' && <NavLink id={navMobileItem.id} to={navMobileItem.link} onClick={() => setNavMobileDisplay('none')}><div className="navMobileItem">{navMobileItem.name}</div></NavLink>}
-                      {navMobileItem.className === 'navMobileItem clickable' && <div id={navMobileItem.id} role="button" tabIndex={0} className="navMobileItem clickable" onKeyDown={(e) => { if (e.key === "Enter") { clickNavItem(e); } }} onClick={clickNavItem}>{navMobileItem.name}</div>}
-                      {navMobileItem.className === 'navMobileSubItem' && <Link id={navMobileItem.id} to={navMobileItem.link}><div role="button" tabIndex={0} className="navMobileItem SubItem" onKeyDown={(e) => { if (e.key === "Enter") { setNavMobileDisplay('none'); } }} onClick={() => setNavMobileDisplay('none')}>{navMobileItem.name}</div></Link>}
+                      {
+                        navMobileItem.className === 'navMobileItem' &&
+                        <NavLink
+                          id={navMobileItem.id}
+                          to={navMobileItem.link}
+                          reloadDocument={
+                            navMobileItem.id === 'navbar-link-home' ||
+                            navMobileItem.id === 'navbar-link-datasets'
+                          }
+                          onClick={() => setNavMobileDisplay('none')}
+                        >
+                          <div className="navMobileItem">{navMobileItem.name}</div>
+                        </NavLink>
+                      }
+                      {
+                        navMobileItem.className === 'navMobileItem clickable' &&
+                        <div
+                          id={navMobileItem.id}
+                          role="button"
+                          tabIndex={0}
+                          className="navMobileItem clickable"
+                          onKeyDown={(e) => { if (e.key === "Enter") { clickNavItem(e); } }}
+                          onClick={clickNavItem}>{navMobileItem.name}
+                        </div>
+                      }
+                      {
+                        navMobileItem.className === 'navMobileSubItem' &&
+                        <Link id={navMobileItem.id} to={navMobileItem.link}>
+                          <div
+                            role="button"
+                            tabIndex={0}
+                            className="navMobileItem SubItem"
+                            onKeyDown={(e) => { if (e.key === "Enter") { setNavMobileDisplay('none'); } }}
+                            onClick={() => setNavMobileDisplay('none')}
+                          >{navMobileItem.name}</div>
+                        </Link>
+                      }
                       {navMobileItem.className === 'navMobileSubTitle' && <div className="navMobileItem">{navMobileItem.name}</div>}
                     </React.Fragment>
                   );

--- a/src/components/Header/components/NavbarDesktop.tsx
+++ b/src/components/Header/components/NavbarDesktop.tsx
@@ -341,7 +341,26 @@ const NavBar = () => {
                   ? (
                     <LiSection key={navkey}>
                       <div className="navTitle directLink">
-                        {
+                        <NavLink
+                          to={navMobileItem.link}
+                          reloadDocument={
+                            navMobileItem.id === 'navbar-link-home' ||
+                            navMobileItem.id === 'navbar-link-datasets'
+                          }
+                          target={navMobileItem.external ? "_blank" : null}
+                        >
+                          <div
+                            id={navMobileItem.id}
+                            onKeyDown={onKeyPressHandler}
+                            role="button"
+                            tabIndex={0}
+                            className={`navText directLink ${shouldBeUnderlined(navMobileItem) ? "shouldBeUnderlined" : ""}`}
+                            onClick={handleMenuClick}
+                          >
+                            {navMobileItem.name}
+                          </div>
+                        </NavLink>
+                        {/* {
                           (navMobileItem.id === 'navbar-link-home' || navMobileItem.id === 'navbar-link-datasets')
                             ? (
                                 <a href={navMobileItem.link} target={navMobileItem.external ? "_blank" : null} rel={navMobileItem.external ? "noopener noreferrer" : null}>
@@ -371,7 +390,7 @@ const NavBar = () => {
                                   </div>
                                 </NavLink>
                             )
-                        }
+                        } */}
                       </div>
                     </LiSection>
                   )

--- a/src/components/Header/components/NavbarDesktop.tsx
+++ b/src/components/Header/components/NavbarDesktop.tsx
@@ -343,11 +343,9 @@ const NavBar = () => {
                       <div className="navTitle directLink">
                         <NavLink
                           to={navMobileItem.link}
-                          reloadDocument={
-                            navMobileItem.id === 'navbar-link-home' ||
-                            navMobileItem.id === 'navbar-link-datasets'
-                          }
+                          reloadDocument={navMobileItem.reloadDocument}
                           target={navMobileItem.external ? "_blank" : null}
+                          rel={navMobileItem.external ? "noopener noreferrer" : null}
                         >
                           <div
                             id={navMobileItem.id}
@@ -360,37 +358,6 @@ const NavBar = () => {
                             {navMobileItem.name}
                           </div>
                         </NavLink>
-                        {/* {
-                          (navMobileItem.id === 'navbar-link-home' || navMobileItem.id === 'navbar-link-datasets')
-                            ? (
-                                <a href={navMobileItem.link} target={navMobileItem.external ? "_blank" : null} rel={navMobileItem.external ? "noopener noreferrer" : null}>
-                                  <div
-                                    id={navMobileItem.id}
-                                    onKeyDown={onKeyPressHandler}
-                                    role="button"
-                                    tabIndex={0}
-                                    className={`navText directLink ${shouldBeUnderlined(navMobileItem) ? "shouldBeUnderlined" : ""}`}
-                                    onClick={handleMenuClick}
-                                  >
-                                    {navMobileItem.name}
-                                  </div>
-                                </a>
-                            )
-                            : (
-                                <NavLink to={navMobileItem.link} target={navMobileItem.external ? "_blank" : null}>
-                                  <div
-                                    id={navMobileItem.id}
-                                    onKeyDown={onKeyPressHandler}
-                                    role="button"
-                                    tabIndex={0}
-                                    className={`navText directLink ${shouldBeUnderlined(navMobileItem) ? "shouldBeUnderlined" : ""}`}
-                                    onClick={handleMenuClick}
-                                  >
-                                    {navMobileItem.name}
-                                  </div>
-                                </NavLink>
-                            )
-                        } */}
                       </div>
                     </LiSection>
                   )
@@ -431,6 +398,7 @@ const NavBar = () => {
                         id={dropItem.id}
                         to={dropItem.link}
                         target={dropItem.external ? "_blank" : null}
+                        rel={dropItem.external ? "noopener noreferrer" : null}
                         className="dropdownItem"
                         key={dropkey}
                         onClick={() => setClickedTitle("")}
@@ -455,6 +423,7 @@ const NavBar = () => {
                         id={dropItem.id}
                         to={dropItem.link}
                         target={dropItem.external ? "_blank" : null}
+                        rel={dropItem.external ? "noopener noreferrer" : null}
                         className="dropdownItem"
                         key={dropkey}
                         onClick={() => setClickedTitle("")}

--- a/src/components/Header/components/NavbarDesktop.tsx
+++ b/src/components/Header/components/NavbarDesktop.tsx
@@ -342,7 +342,7 @@ const NavBar = () => {
                     <LiSection key={navkey}>
                       <div className="navTitle directLink">
                         {
-                          navMobileItem.id === 'navbar-link-home'
+                          (navMobileItem.id === 'navbar-link-home' || navMobileItem.id === 'navbar-link-datasets')
                             ? (
                                 <a href={navMobileItem.link} target={navMobileItem.external ? "_blank" : null} rel={navMobileItem.external ? "noopener noreferrer" : null}>
                                   <div

--- a/src/config/globalHeaderData.tsx
+++ b/src/config/globalHeaderData.tsx
@@ -21,12 +21,14 @@ export const navMobileList = [
     name: 'Home',
     link: '/',
     id: 'navbar-link-home',
+    reloadDocument: true,
     className: 'navMobileItem',
   },
   {
     name: 'Datasets',
     link: '/datasets',
     id: 'navbar-link-datasets',
+    reloadDocument: true,
     className: 'navMobileItem',
   },
   // {


### PR DESCRIPTION
This pull request updates navigation link handling across mobile, tablet, and desktop headers to improve external link support, accessibility, and navigation behavior. The main improvements include adding support for opening external links in new tabs with proper security attributes, ensuring some links reload the document, and refactoring code for consistency.

**Navigation link enhancements:**

* Added `reloadDocument`, `target="_blank"`, and `rel="noopener noreferrer"` support to `NavLink` and `Link` components for external links in `HeaderMobile.tsx` and `HeaderTablet.tsx`, improving external navigation and security. [[1]](diffhunk://#diff-a24b60582f4cd87d68edddcdf8e8868e1118dd6e5ac32ee38e9e5b530bb67593L244-R286) [[2]](diffhunk://#diff-3efb7d60db60ce3f2bc30067988661ab270df495e4263a2122de74e187e30e2dL232-R272)
* Updated `navMobileList` in `globalHeaderData.tsx` to include the `reloadDocument` property for the Home and Datasets links, ensuring these links trigger a full page reload.

**Desktop navigation improvements:**

* Refactored the desktop navbar to consistently use `NavLink` for navigation, added `reloadDocument`, and ensured external links have `target="_blank"` and `rel="noopener noreferrer"` for security. [[1]](diffhunk://#diff-db3e705be5ac4bda037ae5677c459b03e377ad74aba8596264168076df99bd9fL344-L361) [[2]](diffhunk://#diff-db3e705be5ac4bda037ae5677c459b03e377ad74aba8596264168076df99bd9fL373-L374)
* Added `rel="noopener noreferrer"` to dropdown navigation items when `target="_blank"` is set, further improving security for external links. [[1]](diffhunk://#diff-db3e705be5ac4bda037ae5677c459b03e377ad74aba8596264168076df99bd9fR401) [[2]](diffhunk://#diff-db3e705be5ac4bda037ae5677c459b03e377ad74aba8596264168076df99bd9fR426)