### PR TITLE
Use window.location.hash to manage hash parameters

### DIFF
--- a/src/pages/iframe/AdvancedIframePage.tsx
+++ b/src/pages/iframe/AdvancedIframePage.tsx
@@ -5,7 +5,7 @@ const AdvancedIframePage: FC<{ id: string, title: string }> = ({id, title}) => {
   const [urlParamsFromHub, setUrlParamsFromHub] = useState('/');
 
   useEffect(() => {
-    const urlParams = window.location.pathname + window.location.search;
+    const urlParams = window.location.pathname + window.location.search + window.location.hash;
     setUrlParamsFromHub(urlParams);
   }, []);
 


### PR DESCRIPTION
This pull request makes a minor update to the way URL parameters are captured in the `AdvancedIframePage` component. The change ensures that the URL hash fragment is now included along with the pathname and search parameters when setting `urlParamsFromHub`. 

* Include the `window.location.hash` value in the `urlParamsFromHub` state to ensure the full URL (including hash fragment) is captured.